### PR TITLE
Fix target bytes value and README text

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ This repository automates the process of downloading the latest OpenLibrary dump
 
 ## ✨ Files
 
-- `openlibrary_pipeline.py`: Downloads dataset from OpenLibrary and then pushes the to Hugging Face.
+- `openlibrary_pipeline.py`: Downloads the dataset from OpenLibrary and then pushes it to Hugging Face.
 - `.github/workflows//process_openlibrary.yml`: GitHub Actions CI job.

--- a/openlibrary_pipeline.py
+++ b/openlibrary_pipeline.py
@@ -33,7 +33,8 @@ HF_REPO_ID: str = os.getenv("HF_REPO_ID", "sayshara/openlibrary")
 MANIFEST_PATH = "ol_sync_manifest.json"
 CHUNK_SIZE_BYTES = 5 * 1024 * 1024 * 1024  # 5 GB – chunked upload threshold
 
-TARGET_BYTES = 5 * 1024 ** 3   # 3 GB raw JSON per Parquet file
+# Limit Parquet parts to roughly 3 GB of uncompressed JSON data
+TARGET_BYTES = 3 * 1024 ** 3
 BATCH_ROWS   = 50_000          # Arrow/Pandas rows kept in memory before writing
 
 FILES: Dict[str, str] = {


### PR DESCRIPTION
## Summary
- ensure target Parquet chunk size is 3GB as documented
- clarify README wording about pushing to HF

## Testing
- `python -m py_compile openlibrary_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_b_685f38444f648324abe629448e78e8ad