### PR TITLE
Add schema inference and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ This repository automates the process of downloading the latest OpenLibrary dump
 
 - `openlibrary_pipeline.py`: Downloads the dataset from OpenLibrary and then pushes it to Hugging Face.
 - `.github/workflows//process_openlibrary.yml`: GitHub Actions CI job.
+
+## 📑 Schema information
+
+During conversion the pipeline determines the full schema of each OpenLibrary dump.
+The discovered column names and Arrow data types are stored in `<config>_schema.json`
+and uploaded under the `metadata/` directory of the dataset repository. Every
+Parquet file is written using this schema so all parts share identical columns
+and types.


### PR DESCRIPTION
## Summary
- infer full schema before writing parquet files
- save schema as `<config>_schema.json` and upload to dataset
- use fixed schema for each parquet part
- document schema handling in README

## Testing
- `python -m py_compile openlibrary_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_b_686179e303248324af0fdfcf02cd2c23